### PR TITLE
fix custom payload aggregation disconnects

### DIFF
--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/aggregation/AggregationManager.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/aggregation/AggregationManager.java
@@ -51,10 +51,8 @@ public class AggregationManager {
     }
 
     public synchronized static void flushConnection(Connection connection) {
-        TIMER.execute(() -> {
-            PACKET_BUFFER.entrySet().removeIf(e -> !e.getKey().isConnected());
-            flushInternal(connection, PACKET_BUFFER.get(connection));
-        });
+        PACKET_BUFFER.entrySet().removeIf(e -> !e.getKey().isConnected());
+        flushInternal(connection, PACKET_BUFFER.get(connection));
     }
 
     private synchronized static void flushInternal(Connection connection, @Nullable ArrayList<AggregatedEncodePacket> packets) {
@@ -68,12 +66,12 @@ public class AggregationManager {
                 return;
             }
             var sendPackets = new ArrayList<>(packets);
+            packets.clear();
             connection.send(connection.getSending() == PacketFlow.CLIENTBOUND
                             ? new ClientboundCustomPayloadPacket(new PacketAggregationPacket(sendPackets, encoder.getProtocolInfo(), connection))
                             : new ServerboundCustomPayloadPacket(new PacketAggregationPacket(sendPackets, encoder.getProtocolInfo(), connection)),
                     null, true
             );
-            packets.clear();
             connection.flushChannel();
         } catch (Exception e) {
             LogUtils.getLogger().error("NEBL: Skipped: Failed to flush packets.", e);

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/aggregation/PacketAggregationPacket.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/aggregation/PacketAggregationPacket.java
@@ -67,30 +67,30 @@ public class PacketAggregationPacket implements CustomPacketPayload {
      */
     @SuppressWarnings("UnstableApiUsage")
     public void encode(RegistryFriendlyByteBuf buffer) {
-        //skip GenericPacketSplitter
-        if (WALKER.walk(s -> s.anyMatch(frame -> frame.getDeclaringClass() == GenericPacketSplitter.class))) {
-            return;
-        }
+        var splitterProbe = WALKER.walk(s -> s.anyMatch(frame -> frame.getDeclaringClass() == GenericPacketSplitter.class));
         var rawBuf = new RegistryFriendlyByteBuf(ByteBufAllocator.DEFAULT.buffer(), buffer.registryAccess(), buffer.getConnectionType());
         packetsToEncode.forEach(p -> encodePackets(rawBuf, p));
 
         int rawSize = rawBuf.readableBytes();
-        boolean compress = rawSize >= 32;
+        boolean compress = !splitterProbe && rawSize >= 32;
         // B
         buffer.writeBoolean(compress);
         if (compress) {
             // S
             buffer.writeVarInt(rawSize);
             var compressedBuf = new FriendlyByteBuf(ZstdHelper.compress(connection, rawBuf));
-            logCompressRatio(rawSize, compressedBuf.readableBytes());
+            int compressedSize = compressedBuf.readableBytes();
+            logCompressRatio(rawSize, compressedSize);
             buffer.writeBytes(compressedBuf);
+            this.bakedSize = compressedSize;
             compressedBuf.release();
-            this.bakedSize = compressedBuf.readableBytes();
         } else {
             buffer.writeBytes(rawBuf);
             this.bakedSize = rawSize;
         }
-        SimpleStatManager.outRaw(rawSize);
+        if (!splitterProbe) {
+            SimpleStatManager.outRaw(rawSize);
+        }
         rawBuf.release();
     }
 
@@ -146,8 +146,9 @@ public class PacketAggregationPacket implements CustomPacketPayload {
         if (compressed) {
             // S
             int size = data.readVarInt();
+            var compressedData = data.retainedDuplicate();
             try {
-                raw = new RegistryFriendlyByteBuf(ZstdHelper.decompress(connection, data.retainedDuplicate(), size), data.registryAccess(), data.getConnectionType());
+                raw = new RegistryFriendlyByteBuf(ZstdHelper.decompress(connection, compressedData, size), data.registryAccess(), data.getConnectionType());
             } catch (Exception e) {
                 LogUtils.getLogger().error("NEBL: Failed to decompress packet aggregation from {}, clearing cache and skipping. This is expected after server switches.", connection.getRemoteAddress());
                 LogUtils.getLogger().error("NEBL: Decompression error details:", e);
@@ -155,6 +156,8 @@ public class PacketAggregationPacket implements CustomPacketPayload {
                 AggregationManager.clearCache(connection);
                 data.release();
                 return;
+            } finally {
+                compressedData.release();
             }
         } else {
             raw = new RegistryFriendlyByteBuf(data.retain(), data.registryAccess(), data.getConnectionType());

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/indextype/NamespaceIndexManager.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/indextype/NamespaceIndexManager.java
@@ -286,14 +286,16 @@ public class NamespaceIndexManager {
             PATHS.add(new ArrayList<>());
             namespaceIndex.getAndIncrement();
         }
-        PATH_MAPS.compute(namespaceIndex.get() - 1, (namespaceId1, pathMap) -> {
+        int namespaceId = NAMESPACE_MAP.getInt(packetId.getNamespace());
+        PATH_MAPS.compute(namespaceId, (namespaceId1, pathMap) -> {
             if (pathMap == null) {
                 pathMap = new Object2IntOpenHashMap<>();
+                pathMap.defaultReturnValue(-1);
             }
             pathMap.put(packetId.getPath(), pathMap.size());
             return pathMap;
         });
-        PATHS.get(namespaceIndex.get() - 1).add(packetId.getPath());
+        PATHS.get(namespaceId).add(packetId.getPath());
     }
 
     public static boolean contains(ResourceLocation type) {

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/CustomPacketPayloadMixin.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/CustomPacketPayloadMixin.java
@@ -34,13 +34,15 @@ public class CustomPacketPayloadMixin {
 
     @Redirect(method = "decode(Lnet/minecraft/network/FriendlyByteBuf;)Lnet/minecraft/network/protocol/common/custom/CustomPacketPayload;", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/FriendlyByteBuf;readResourceLocation()Lnet/minecraft/resources/ResourceLocation;"))
     private ResourceLocation neblIndexedHeaderDecode(FriendlyByteBuf buf) {
+        var tryRead = new FriendlyByteBuf(buf.retainedDuplicate());
         try {
-            var tryRead = new FriendlyByteBuf(buf.retainedDuplicate());
             var tryType = tryRead.readResourceLocation();
             if (NotEnoughBandwidthLegacyConfig.skipType(tryType.toString())) {
                 return buf.readResourceLocation();
             }
         } catch (Exception ignored) {
+        } finally {
+            tryRead.release();
         }
         if (val$protocol != ConnectionProtocol.PLAY) {
             return buf.readResourceLocation();

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/DiscardedPayloadMixin.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/DiscardedPayloadMixin.java
@@ -1,0 +1,23 @@
+package cn.ussshenzhou.notenoughbandwidth.mixin;
+
+import cn.ussshenzhou.notenoughbandwidth.NotEnoughBandwidthLegacyConfig;
+import net.minecraft.network.protocol.common.custom.DiscardedPayload;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * Keep discarded clientbound custom payload decoding in line with NEBL's packet limit.
+ */
+@Mixin(DiscardedPayload.class)
+public class DiscardedPayloadMixin {
+
+    @ModifyVariable(method = "lambda$codec$1", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private static int neblUseConfiguredClientboundPayloadLimit(int maxSize) {
+        if (maxSize != 1_048_576) {
+            return maxSize;
+        }
+        var cfg = NotEnoughBandwidthLegacyConfig.get();
+        return cfg == null ? maxSize : Math.max(maxSize, cfg.getMaxPacketSize());
+    }
+}

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/DiscardedPayloadMixin.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/DiscardedPayloadMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 @Mixin(DiscardedPayload.class)
 public class DiscardedPayloadMixin {
 
-    @ModifyVariable(method = "lambda$codec$1", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    @ModifyVariable(method = "lambda$codec$1", at = @At("HEAD"), argsOnly = true, ordinal = 0, require = 0)
     private static int neblUseConfiguredClientboundPayloadLimit(int maxSize) {
         if (maxSize != 1_048_576) {
             return maxSize;

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/zstd/ZstdHelper.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/zstd/ZstdHelper.java
@@ -81,7 +81,7 @@ public class ZstdHelper {
             return true;
         }
         var uuid = to.getUUID();
-        var use = NotEnoughBandwidthLegacyConfig.get().playersDoNotUseContext.contains(uuid.toString());
+        var use = !NotEnoughBandwidthLegacyConfig.get().playersDoNotUseContext.contains(uuid.toString());
         CONNECTION_USE_CONTEXT.put(connection, use);
         return use;
     }

--- a/src/main/resources/nebl.mixins.json
+++ b/src/main/resources/nebl.mixins.json
@@ -7,6 +7,7 @@
     "ChunkMapMixin",
     "ConnectionMixin",
     "CustomPacketPayloadMixin",
+    "DiscardedPayloadMixin",
     "NetworkRegistryMixin",
     "PacketDecoderMixin",
     "PacketEncoderMixin",


### PR DESCRIPTION
- flush aggregation buffers synchronously and clear queued packets before sending to avoid recursive duplicate flushes
- keep aggregation encoding valid during splitter probes and fix compressed size/stat accounting
- release retained decode/probe buffers correctly
- fix namespace/path index lookup for custom payload ids
- respect maxPacketSize for discarded clientbound custom payloads
- correct Zstd context opt-out handling